### PR TITLE
Add FormatProviderPatternTests

### DIFF
--- a/Tests/FormatProviderTests.swift
+++ b/Tests/FormatProviderTests.swift
@@ -67,3 +67,40 @@ class FormatProviderTests: XCTestCase {
         XCTAssertNil(format)
     }
 }
+
+class FormatProviderPatternTests: XCTestCase {
+
+    func testAllPatternsInBundle() throws {
+
+        let bundle = Bundle(for: ListItemFormatter.self)
+
+        let localeInformation = try LocaleInformation(bundle: bundle)
+        let provider = FormatProvider(bundle: bundle)
+
+        XCTAssertFalse(localeInformation.localeIdentifiers.isEmpty)
+
+        let combinations: [(ListItemFormatter.Mode, ListItemFormatter.Style)] = [
+            (.standard, .default),
+            (.standard, .short),
+            (.standard, .narrow),
+            (.or, .default),
+            (.or, .short),
+            (.or, .narrow),
+            (.unit, .default),
+            (.unit, .short),
+            (.unit, .narrow),
+        ]
+
+        for identifier in localeInformation.localeIdentifiers {
+            for (mode, style) in combinations {
+
+                let locale = Locale(identifier: identifier)
+                let format = provider.format(for: locale)
+                let patterns = format?.getPatterns(for: style, mode: mode)
+
+                XCTAssertNotNil(format)
+                XCTAssertNotNil(patterns)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, the tests never really ensured that a `Format.Pattern` object would exist for all different mode/style combinations.  

This change adds a specific test to enumerate through all of the data found in the framework bundle to ensure that the pattens returned are not nil. This will be useful in the future when we come to repackaging the underlying cldr data for version updates to be sure that nothing gets broken. 