### PR TITLE
Test Carthage builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ formatter.attributedString(from: ["Swift", "Objective-C"]) // NSAttributedString
 </html>
 */
 ```
+
+## Installation
+
+### Carthage
+
+To integrate ListItemFormatter into your Xcode project using [Carthage](https://github.com/Carthage/Carthage), specify it in your `Cartfile`:
+
+```
+github "liamnichols/ListItemFormatter"
+```
+
+Follow the [instructions](https://github.com/Carthage/Carthage#quick-start) to add ListItemFormatter.framework to your project.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,6 +40,7 @@ lane :test do
 
   run_tests(scheme: "ListItemFormatter macOS", destination: "platform=macOS", clean: true)
 
+  carthage(command: "build", platform: "all", no_skip_current: true)
   pod_lib_lint
 end
 


### PR DESCRIPTION
With the shared framework schemes, there should be no problem to install ListItemFormatter via Carthage. This pull request adds [`carthage build --no-skip-current`](https://github.com/Carthage/Carthage#supporting-carthage-for-your-framework) to the CI configuration to test Carthage builds:

https://travis-ci.org/bcylin/ListItemFormatter/builds/516203329#L1644

Close #3.