### PR TITLE
API Interface Changes

### DIFF
--- a/Source/ListItemFormatter.swift
+++ b/Source/ListItemFormatter.swift
@@ -104,7 +104,7 @@ import Foundation
     ///
     /// - Returns: A string representation of `list` formatted using the receiver’s
     ///  current settings.
-    @objc public func string(from list: [String]) -> String {
+    @objc(stringFromList:) public func string(from list: [String]) -> String {
         return string(for: list) ?? ""
     }
 
@@ -124,7 +124,7 @@ import Foundation
     ///
     /// - Returns: An attributed string representation of `list` formatted using the
     ///  receiver’s current settings.
-    @objc public func attributedString(from list: [String]) -> NSAttributedString {
+    @objc(attributedStringFromList:) public func attributedString(from list: [String]) -> NSAttributedString {
 
         return attributedString(for: list, withDefaultAttributes: defaultAttributes) ?? NSAttributedString()
     }

--- a/Source/ListItemFormatter.swift
+++ b/Source/ListItemFormatter.swift
@@ -104,8 +104,8 @@ import Foundation
     ///
     /// - Returns: A string representation of `list` formatted using the receiver’s
     ///  current settings.
-    @objc public func string(from list: [String]) -> String? {
-        return string(for: list)
+    @objc public func string(from list: [String]) -> String {
+        return string(for: list) ?? ""
     }
 
     /// Returns an attributed strign representation of the given list items formatted
@@ -124,21 +124,26 @@ import Foundation
     ///
     /// - Returns: An attributed string representation of `list` formatted using the
     ///  receiver’s current settings.
-    @objc public func attributedString(from list: [String]) -> NSAttributedString? {
+    @objc public func attributedString(from list: [String]) -> NSAttributedString {
 
-        return attributedString(for: list, withDefaultAttributes: defaultAttributes)
+        return attributedString(for: list, withDefaultAttributes: defaultAttributes) ?? NSAttributedString()
     }
 
-    public override init() {
-        mode = .standard
-        style = .default
-        locale = .autoupdatingCurrent
+    public convenience override init() {
+        self.init(formatProvider: FormatProvider())
+    }
+
+    // MARK: - Internal Interface
+
+    let formatProvider: FormatProvider
+
+    init(formatProvider: FormatProvider) {
+        self.formatProvider = formatProvider
+        self.mode = .standard
+        self.style = .default
+        self.locale = .autoupdatingCurrent
         super.init()
     }
-
-    // MARK: - Private
-
-    private let formatProvider = FormatProvider()
 
     // MARK: - NSSecureCoding
 
@@ -150,6 +155,7 @@ import Foundation
             let style = Style(rawValue: aDecoder.decodeInteger(forKey: "style")),
             let locale = (aDecoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale?) else { return nil }
 
+        self.formatProvider = FormatProvider()
         self.mode = mode
         self.style = style
         self.locale = locale

--- a/Tests/LNListPatternFormatterObjcInterfaceTests.m
+++ b/Tests/LNListPatternFormatterObjcInterfaceTests.m
@@ -36,8 +36,13 @@
     formatter.style = LNListItemFormatterStyleDefault;
     formatter.mode = LNListItemFormatterModeOr;
 
-    NSString *result = [formatter stringFrom:[NSArray arrayWithObjects:@"one", @"two", nil]];
+    NSArray *items = [NSArray arrayWithObjects:@"one", @"two", nil];
+
+    NSString *result = [formatter stringFromList:items];
     XCTAssertTrue([result isEqualToString:@"one or two"]);
+
+    NSAttributedString *attributedResult = [formatter attributedStringFromList:items];
+    XCTAssertTrue([attributedResult.string isEqualToString:@"one or two"]);
 }
 
 @end

--- a/Tests/ListItemFormatterTests.swift
+++ b/Tests/ListItemFormatterTests.swift
@@ -123,7 +123,7 @@ class ListItemFormatterTests: XCTestCase {
 
             formatter.locale = Locale(identifier: identifier)
 
-            let output = formatter.string(from: ["ONE", "TWO", "THREE"]) ?? ""
+            let output = formatter.string(from: ["ONE", "TWO", "THREE"])
             XCTAssertTrue(output.contains("ONE"))
             XCTAssertTrue(output.contains("TWO"))
             XCTAssertTrue(output.contains("THREE"))
@@ -200,17 +200,30 @@ class ListItemFormatterTests: XCTestCase {
 
         let output = formatter.attributedString(from: ["one", "two"])
         XCTAssertNotNil(output)
-        XCTAssertEqual(output?.string, "one and two")
+        XCTAssertEqual(output.string, "one and two")
 
         var range = NSRange(location: NSNotFound, length: 0)
 
-        XCTAssertEqual(output?.attribute(.identifier, at: 0, effectiveRange: &range) as? String, "ITEM")
+        XCTAssertEqual(output.attribute(.identifier, at: 0, effectiveRange: &range) as? String, "ITEM")
         XCTAssertEqual(range, NSRange(location: 0, length: 3))
 
-        XCTAssertEqual(output?.attribute(.identifier, at: 3, effectiveRange: &range) as? String, "DEFAULT")
+        XCTAssertEqual(output.attribute(.identifier, at: 3, effectiveRange: &range) as? String, "DEFAULT")
         XCTAssertEqual(range, NSRange(location: 3, length: 5))
 
-        XCTAssertEqual(output?.attribute(.identifier, at: 8, effectiveRange: &range) as? String, "ITEM")
+        XCTAssertEqual(output.attribute(.identifier, at: 8, effectiveRange: &range) as? String, "ITEM")
         XCTAssertEqual(range, NSRange(location: 8, length: 3))
+    }
+
+    func testFallbackValues() {
+
+        let bundle = Bundle(for: ListItemFormatterTests.self)
+        let provider = FormatProvider(bundle: bundle)
+        let formatter = ListItemFormatter(formatProvider: provider)
+
+        let string = formatter.string(from: ["ONE", "TWO", "THREE"])
+        let attributedString = formatter.attributedString(from: ["ONE", "TWO", "THREE"])
+
+        XCTAssertEqual(string, "")
+        XCTAssertEqual(attributedString, NSAttributedString())
     }
 }


### PR DESCRIPTION
Slight adjustments to the API interface for initial release: 

- `string(from:)` no longer returns an optional
- `attributedString(from:)` no longer returns an optional
- `-[LNListItemFormatter stringFrom:]` is now `-[LNListItemFormatter stringFromList:]` 
- `-[LNListItemFormatter attributedStringFrom:]` is now `-[LNListItemFormatter attributedStringFromList:]` 

Closes #17 

Note that I had to expose the `FormatterProvider` as an initialiser value for the internal interface so that I could pass in a version with a bad bundle that allows me to test that the default values are used when the data is bad (to keep 100% coverage) 