### PR TITLE
Generate docs

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -2,7 +2,7 @@ clean: true
 author: 'Liam Nichols'
 author_url: https://github.com/liamnichols
 github_url: https://github.com/liamnichols/ListItemFormatter
-github_file_prefix: https://github.com/liamnichols/ListItemFormatter/tree/master
+github_file_prefix: https://github.com/liamnichols/ListItemFormatter/blob/0.0.1
 xcodebuild_arguments: [-project, ListItemFormatter.xcodeproj, -scheme, 'ListItemFormatter iOS']
 module: ListItemFormatter
 module_version: 0.0.1

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -1,0 +1,11 @@
+clean: true
+author: 'Liam Nichols'
+author_url: https://github.com/liamnichols
+github_url: https://github.com/liamnichols/ListItemFormatter
+github_file_prefix: https://github.com/liamnichols/ListItemFormatter/blob/master
+xcodebuild_arguments: [-project, ListItemFormatter.xcodeproj, -scheme, 'ListItemFormatter iOS']
+module: ListItemFormatter
+module_version: 1.0
+output: docs
+theme: fullwidth
+skip_undocumented: true

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -2,10 +2,10 @@ clean: true
 author: 'Liam Nichols'
 author_url: https://github.com/liamnichols
 github_url: https://github.com/liamnichols/ListItemFormatter
-github_file_prefix: https://github.com/liamnichols/ListItemFormatter/blob/master
+github_file_prefix: https://github.com/liamnichols/ListItemFormatter/tree/master
 xcodebuild_arguments: [-project, ListItemFormatter.xcodeproj, -scheme, 'ListItemFormatter iOS']
 module: ListItemFormatter
-module_version: 1.0
+module_version: 0.0.1
 output: docs
 theme: fullwidth
 skip_undocumented: true

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem 'fastlane'
 gem 'cocoapods', '1.6.1'
+gem 'jazzy'
 
 # For import_cldr_data.rb
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    ffi (1.10.0)
     fileutils (1.2.0)
     fourflusher (2.2.0)
     fuzzy_match (2.0.4)
@@ -138,8 +139,18 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jazzy (0.9.4)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (>= 2.0.6, < 4.0)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
     json (2.2.0)
     jwt (2.1.0)
+    liferaft (0.0.6)
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -150,13 +161,19 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustache (0.99.8)
     nanaimo (0.2.6)
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
+    open4 (1.3.4)
     os (1.0.0)
     plist (3.5.0)
     public_suffix (2.0.5)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    redcarpet (3.4.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -165,6 +182,11 @@ GEM
     rouge (2.0.7)
     ruby-macho (1.4.0)
     rubyzip (1.2.2)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -175,6 +197,7 @@ GEM
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
+    sqlite3 (1.4.0)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -191,6 +214,8 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.5.0)
     word_wrap (1.0.0)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.8.2)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -210,6 +235,7 @@ DEPENDENCIES
   faraday
   fastlane
   fileutils
+  jazzy
   json
 
 BUNDLED WITH

--- a/ListItemFormatter.podspec
+++ b/ListItemFormatter.podspec
@@ -5,6 +5,7 @@ Pod::Spec.new do |s|
   s.summary = 'Localised list formatting in Swift and Objective-C'
   s.description = 'ListItemFormatter is an NSFormatter subclass that supports formatting list items to the Unicode CLDR specification.'
   s.homepage = 'https://github.com/liamnichols/ListItemFormatter'
+  s.documentation_url = 'https://liamnichols.github.io/ListItemFormatter'
   s.author = { 'liamnichols' => 'liam.nichols.ln@gmail.com' }
   s.social_media_url = 'https://twitter.com/liamnichols_'
   s.source = { :git => 'https://github.com/liamnichols/ListItemFormatter.git', :tag => "v#{s.version}" }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,6 +27,8 @@ lane :update_version do |options|
   version_bump_podspec(path: "ListItemFormatter.podspec", version_number: version_number)
 
   git_commit(path: ".", message: "Update version to '#{version_number}'")
+  update_docs(version_number: version_number)
+
   push_to_git_remote
 
   carthage(command: "build", platform: "all", no_skip_current: true)
@@ -86,6 +88,21 @@ lane :test do
 
   carthage(command: "build", platform: "all", no_skip_current: true)
   pod_lib_lint
+end
+
+desc "Update docs and commit changes."
+lane :update_docs do |options|
+
+  UI.message "Updating docs..."
+  jazzy(config: ".jazzy.yml")
+  version_number = options[:version_number] || get_version_number(xcodeproj: "ListItemFormatter.xcodeproj", target: "ListItemFormatter iOS")
+
+  docs_updated = Dir.chdir("..") do
+    sh("git add docs")
+    sh("git status --porcelain docs")
+  end
+
+  git_commit(path: "docs", message: "Update docs to '#{version_number}'") if docs_updated
 end
 
 lane :import_data do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,7 @@ lane :update_docs do |options|
 
   Dir.chdir("..") do
     yml = File.read(".jazzy.yml")
-    yml = yml.gsub(%r{:\s\d+\.\d+(\.\d+)?}i, ": #{version_number}")
+    yml = yml.gsub(%r{\d+\.\d+(\.\d+)?}, "#{version_number}")
     File.open(".jazzy.yml", "w") { |file| file.puts yml }
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,8 +105,9 @@ lane :update_docs do |options|
   jazzy(config: ".jazzy.yml")
 
   docs_updated = Dir.chdir("..") do
-    sh("git add docs")
-    sh("git status --porcelain docs")
+    has_diff = ! sh("git status --porcelain docs").empty?
+    sh("git add docs") if has_diff
+    has_diff
   end
 
   git_commit(path: "docs", message: "Update docs to '#{version_number}'") if docs_updated

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,8 +94,15 @@ desc "Update docs and commit changes."
 lane :update_docs do |options|
 
   UI.message "Updating docs..."
-  jazzy(config: ".jazzy.yml")
   version_number = options[:version_number] || get_version_number(xcodeproj: "ListItemFormatter.xcodeproj", target: "ListItemFormatter iOS")
+
+  Dir.chdir("..") do
+    yml = File.read(".jazzy.yml")
+    yml = yml.gsub(%r{:\s\d+\.\d+(\.\d+)?}i, ": #{version_number}")
+    File.open(".jazzy.yml", "w") { |file| file.puts yml }
+  end
+
+  jazzy(config: ".jazzy.yml")
 
   docs_updated = Dir.chdir("..") do
     sh("git add docs")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,7 +87,7 @@ lane :test do
   run_tests(scheme: "ListItemFormatter macOS", destination: "platform=macOS", clean: true)
 
   carthage(command: "build", platform: "all", no_skip_current: true)
-  pod_lib_lint
+  pod_lib_lint(allow_warnings: true)
 end
 
 desc "Update docs and commit changes."


### PR DESCRIPTION
This pull request adds `fastlane update_docs` to generate docs using [Jazzy](https://github.com/realm/jazzy) during `fastlane update_version`.

It will be available at <https://liamnichols.github.io/ListItemFormatter> after enabling [GitHub Pages](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages) (and adding a commit that includes `./docs`).

<img width="800" src="https://user-images.githubusercontent.com/2032500/55646142-55752500-57d2-11e9-8272-56dbce507569.png">
