### PR TITLE
Change supported Swift Version to 5.0 using Xcode 10.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.1
+osx_image: xcode10.2
 language: swift
 script:
   - bundle exec fastlane test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.2.1
+osx_image: xcode10.2
 language: swift
 script:
   - bundle exec fastlane test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 osx_image: xcode10.2
 language: swift
 script:
+  - sudo mkdir '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 9.3.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift'
   - bundle exec fastlane test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.2
+osx_image: xcode10.2.1
 language: swift
 script:
   - bundle exec fastlane test

--- a/ListItemFormatter.podspec
+++ b/ListItemFormatter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ListItemFormatter'
-  s.version = '0.0.1'
+  s.version = '0.1.0'
   s.license = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.summary = 'Localised list formatting in Swift and Objective-C'
   s.description = 'ListItemFormatter is an NSFormatter subclass that supports formatting list items to the Unicode CLDR specification.'
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/liamnichols_'
   s.source = { :git => 'https://github.com/liamnichols/ListItemFormatter.git', :tag => "v#{s.version}" }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
 
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
   s.source_files  = "Source/**/*.{h,swift}"
   s.resources = 'Source/*.xcassets'
 end

--- a/ListItemFormatter.podspec
+++ b/ListItemFormatter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ListItemFormatter'
-  s.version = '0.1.0'
+  s.version = '0.0.1'
   s.license = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.summary = 'Localised list formatting in Swift and Objective-C'
   s.description = 'ListItemFormatter is an NSFormatter subclass that supports formatting list items to the Unicode CLDR specification.'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/liamnichols_'
   s.source = { :git => 'https://github.com/liamnichols/ListItemFormatter.git', :tag => "v#{s.version}" }
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
 

--- a/ListItemFormatter.xcodeproj/project.pbxproj
+++ b/ListItemFormatter.xcodeproj/project.pbxproj
@@ -405,7 +405,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Liam Nichols";
 				TargetAttributes = {
 					533285F72254EDE400140D57 = {
@@ -426,7 +426,7 @@
 					};
 					53F3612A222E656500D93A5D = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -616,7 +616,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -639,7 +639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -829,7 +829,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -890,7 +890,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -910,7 +910,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -925,6 +925,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -933,7 +934,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -948,6 +949,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -966,6 +968,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -984,6 +987,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ListItemFormatter.xcodeproj/project.pbxproj
+++ b/ListItemFormatter.xcodeproj/project.pbxproj
@@ -405,7 +405,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Liam Nichols";
 				TargetAttributes = {
 					533285F72254EDE400140D57 = {
@@ -422,11 +422,11 @@
 					};
 					53F36121222E656500D93A5D = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1020;
+						LastSwiftMigration = 1010;
 					};
 					53F3612A222E656500D93A5D = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1020;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -616,7 +616,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -631,7 +631,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvos";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -640,7 +639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -655,7 +654,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvos";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -674,7 +672,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -693,7 +690,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -719,7 +715,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macos";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -744,7 +739,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macos";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -763,7 +757,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -782,7 +775,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -918,7 +910,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -933,7 +925,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -942,7 +933,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 2;
@@ -957,7 +948,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -976,7 +966,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -995,7 +984,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ListItemFormatter.xcodeproj/project.pbxproj
+++ b/ListItemFormatter.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 					};
 					53F36121222E656500D93A5D = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 					53F3612A222E656500D93A5D = {
 						CreatedOnToolsVersion = 10.1;
@@ -837,7 +837,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -898,7 +898,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -933,7 +933,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -957,7 +957,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -976,7 +976,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -995,7 +995,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ListItemFormatter.xcodeproj/project.pbxproj
+++ b/ListItemFormatter.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvos";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -654,6 +655,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvos";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -672,6 +674,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -690,6 +693,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).tvostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -715,6 +719,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macos";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -739,6 +744,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macos";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -757,6 +763,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -775,6 +782,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).macostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -838,7 +846,7 @@
 				PRODUCT_NAME = ListItemFormatter;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -898,7 +906,7 @@
 				PRODUCT_NAME = ListItemFormatter;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -925,7 +933,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -949,7 +957,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -968,7 +976,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -987,7 +995,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).iostests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ListItemFormatter.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ListItemFormatter.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter iOS.xcscheme
+++ b/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter macOS.xcscheme
+++ b/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter tvOS.xcscheme
+++ b/ListItemFormatter.xcodeproj/xcshareddata/xcschemes/ListItemFormatter tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/SupportingFiles/Info.plist
+++ b/Source/SupportingFiles/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Source/SupportingFiles/Info.plist
+++ b/Source/SupportingFiles/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,12 +77,12 @@ lane :test do
 
   clear_derived_data
 
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone XS (12.1)", clean: true)
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)")
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)")
 
-  run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.1)", clean: true)
+  run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 
   run_tests(scheme: "ListItemFormatter macOS", destination: "platform=macOS", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,9 @@ lane :test do
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)", clean: true)
+
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)", clean: true)    
+  
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s Plus (9.3)", clean: true)
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,7 +80,7 @@ lane :test do
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)", clean: true)    
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)", clean: true)
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s Plus (9.3)", clean: true)
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,8 +79,6 @@ lane :test do
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6 (9.3)")
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ lane :test do
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)", clean: true)
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3)", clean: true)    
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)", clean: true)    
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)", clean: true)
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,7 +80,7 @@ lane :test do
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3.1)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6 (9.3)")
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,6 +87,7 @@ lane :test do
   run_tests(scheme: "ListItemFormatter macOS", destination: "platform=macOS", clean: true)
 
   carthage(command: "build", platform: "all", no_skip_current: true)
+  
   pod_lib_lint(allow_warnings: true)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,7 +78,9 @@ lane :test do
   clear_derived_data
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)")
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,9 +78,9 @@ lane :test do
   clear_derived_data
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3.1)")
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,9 +78,7 @@ lane :test do
   clear_derived_data
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3.1)")
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,7 +78,9 @@ lane :test do
   clear_derived_data
 
   run_tests(scheme: "ListItemFormatter iOS", device: "iPhone Xs (12.2)", clean: true)
-  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (12.2)")
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone X (11.4)", clean: true)
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 7 (10.3)", clean: true)    
+  run_tests(scheme: "ListItemFormatter iOS", device: "iPhone 6s (9.3)", clean: true)
 
   run_tests(scheme: "ListItemFormatter tvOS", device: "Apple TV (12.2)", clean: true)
 


### PR DESCRIPTION
## Summary 

support Swift 5.0 and Xcode 10.2

## Detail

* Configure Swift Compile version to 5.0
* iOS Deployment Target bump to 11.0
* Build setting to Xcode 10.2

## Test

- [x] Build Okay
- [x] Local `bundle exec fastlane test`