### PR TITLE
Use a resource bundle when distributing via CocoaPods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
       run: carthage build --platform all --no-skip-current
 
     # Verify CocoaPods
-    - name: Pod Spec Lint
-      run: bundle exec pod spec lint
+    - name: Verify CocoaPods
+      run: bundle exec pod lib lint

--- a/ListItemFormatter.podspec
+++ b/ListItemFormatter.podspec
@@ -16,5 +16,10 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
   s.source_files  = "Source/**/*.{h,swift}"
-  s.resources = 'Source/*.xcassets'
+  s.resource_bundles = { 'ListItemFormatter' => ['Source/*.xcassets'] }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/*.{h,swift}'
+    test_spec.resources = 'Tests/Resources/*.plist'
+  end
 end

--- a/ListItemFormatter.xcodeproj/project.pbxproj
+++ b/ListItemFormatter.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		534C9A002235924A00B951D4 /* LNListPatternFormatterObjcInterfaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 539CE7E82232B60000403C74 /* LNListPatternFormatterObjcInterfaceTests.m */; };
 		534C9A012235924A00B951D4 /* ArchivedFormatter_Invalid.plist in Resources */ = {isa = PBXBuildFile; fileRef = 534C99CA22357AB900B951D4 /* ArchivedFormatter_Invalid.plist */; };
 		534C9A022235924A00B951D4 /* ArchivedFormatter_Valid.plist in Resources */ = {isa = PBXBuildFile; fileRef = 534C99CB22357ABA00B951D4 /* ArchivedFormatter_Valid.plist */; };
+		5397036326A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5397036226A1CD1200D1F6C3 /* Bundle+Resources.swift */; };
+		5397036426A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5397036226A1CD1200D1F6C3 /* Bundle+Resources.swift */; };
+		5397036526A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5397036226A1CD1200D1F6C3 /* Bundle+Resources.swift */; };
 		539CE7D72231BE0000403C74 /* Resources.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 539CE7D62231BE0000403C74 /* Resources.xcassets */; };
 		539CE7DA2231C23B00403C74 /* FormatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539CE7D92231C23B00403C74 /* FormatProvider.swift */; };
 		539CE7DE2231C56300403C74 /* LocaleInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539CE7DD2231C56300403C74 /* LocaleInformation.swift */; };
@@ -100,6 +103,7 @@
 		534C99D322358F5600B951D4 /* Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Format.swift; sourceTree = "<group>"; };
 		534C99DA223590F600B951D4 /* ListItemFormatter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ListItemFormatter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		534C99E2223590F600B951D4 /* ListItemFormatterTests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ListItemFormatterTests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5397036226A1CD1200D1F6C3 /* Bundle+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Resources.swift"; sourceTree = "<group>"; };
 		539CE7D62231BE0000403C74 /* Resources.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Resources.xcassets; sourceTree = "<group>"; };
 		539CE7D92231C23B00403C74 /* FormatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatProvider.swift; sourceTree = "<group>"; };
 		539CE7DD2231C56300403C74 /* LocaleInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleInformation.swift; sourceTree = "<group>"; };
@@ -181,6 +185,7 @@
 			isa = PBXGroup;
 			children = (
 				539CE7DF2231C5E600403C74 /* NSDataAsset+ListItemFormatter.swift */,
+				5397036226A1CD1200D1F6C3 /* Bundle+Resources.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -510,6 +515,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5332861D2254EED300140D57 /* LocaleInformation.swift in Sources */,
+				5397036526A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */,
 				5332861F2254EED300140D57 /* NSDataAsset+ListItemFormatter.swift in Sources */,
 				5332861A2254EED300140D57 /* ListItemFormatter.swift in Sources */,
 				5332861E2254EED300140D57 /* Format.swift in Sources */,
@@ -537,6 +543,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				534C99F4223591F800B951D4 /* LocaleInformation.swift in Sources */,
+				5397036426A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */,
 				534C99F6223591F800B951D4 /* NSDataAsset+ListItemFormatter.swift in Sources */,
 				534C99F1223591F800B951D4 /* ListItemFormatter.swift in Sources */,
 				534C99F5223591F800B951D4 /* Format.swift in Sources */,
@@ -565,6 +572,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				539CE7DA2231C23B00403C74 /* FormatProvider.swift in Sources */,
+				5397036326A1CD1200D1F6C3 /* Bundle+Resources.swift in Sources */,
 				539CE7E42232657D00403C74 /* ListPatternBuilder.swift in Sources */,
 				534C99D422358F5600B951D4 /* Format.swift in Sources */,
 				539CE7E02231C5E600403C74 /* NSDataAsset+ListItemFormatter.swift in Sources */,

--- a/Source/Extensions/Bundle+Resources.swift
+++ b/Source/Extensions/Bundle+Resources.swift
@@ -1,0 +1,44 @@
+/// MIT License
+///
+/// Copyright (c) 2020 Liam Nichols
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+import Foundation
+
+extension Bundle {
+    /// Returns the `Bundle` instance that holds the resources for `ListItemFormatter`.
+    static let resources: Bundle = {
+        let frameworkBundle = Bundle(for: ListItemFormatter.self)
+
+        #if COCOAPODS
+        // When using CocoaPods, resources are moved into a separate resource bundle, load that
+        return Bundle(
+            url: frameworkBundle.url(
+                forResource: "ListItemFormatter",
+                withExtension: "bundle"
+            )!
+        )!
+
+        #else
+        // Alternatively just return the framework bundle itself
+        return frameworkBundle
+        #endif
+    }()
+}

--- a/Source/FormatProvider.swift
+++ b/Source/FormatProvider.swift
@@ -41,7 +41,7 @@ final class FormatProvider {
         return (try? LocaleInformation(bundle: bundle)) ?? LocaleInformation()
     }()
 
-    init(bundle: Bundle = Bundle(for: FormatProvider.self)) {
+    init(bundle: Bundle = .resources) {
 
         cache = NSCache()
         cache.countLimit = 5

--- a/Tests/FormatProviderTests.swift
+++ b/Tests/FormatProviderTests.swift
@@ -72,7 +72,7 @@ class FormatProviderPatternTests: XCTestCase {
 
     func testAllPatternsInBundle() throws {
 
-        let bundle = Bundle(for: ListItemFormatter.self)
+        let bundle = Bundle.resources
 
         let localeInformation = try LocaleInformation(bundle: bundle)
         let provider = FormatProvider(bundle: bundle)


### PR DESCRIPTION
When attempting to statically link pod dependencies, it came to my attention that you could not do so when .xcassets catalogs were specified as `resources`. I think this relates to CocoaPods/CocoaPods#8431.

It seems that the workaround/proper way to do this is to use resource bundles instead so this change aims to do exactly that.

In this PR, i do the following:

1. Support loading resources from the custom bundle when integrated using CocoaPods
2. Add a test_spec in the podspec that will verify the changes in a CocoaPods generated environment too 
3. Update the CI tests to run `pod lib lint` and not `pod spec lint` to check the local changes in PR checks